### PR TITLE
Add basic unit tests for modules

### DIFF
--- a/proto-dialectics/tests/cycle_tests.rs
+++ b/proto-dialectics/tests/cycle_tests.rs
@@ -1,0 +1,37 @@
+use proto_dialectics::{Antithesis, DialecticalCycle, Thesis};
+
+#[test]
+fn add_valid_antithesis() {
+    let thesis = Thesis::new("A".to_string(), 0.5);
+    let mut cycle = DialecticalCycle::new(thesis.clone());
+    let anti = Antithesis::new("not A".to_string(), 0.5, thesis.content.clone());
+    assert!(cycle.add_antithesis(anti));
+    assert!(cycle.antithesis.is_some());
+}
+
+#[test]
+fn add_invalid_antithesis() {
+    let thesis = Thesis::new("A".to_string(), 0.5);
+    let mut cycle = DialecticalCycle::new(thesis);
+    let anti = Antithesis::new("not A".to_string(), 0.5, "B".to_string());
+    assert!(!cycle.add_antithesis(anti));
+    assert!(cycle.antithesis.is_none());
+}
+
+#[test]
+fn synthesize_with_valid_antithesis() {
+    let thesis = Thesis::new("A".to_string(), 0.5);
+    let mut cycle = DialecticalCycle::new(thesis.clone());
+    let anti = Antithesis::new("not A".to_string(), 0.5, thesis.content.clone());
+    assert!(cycle.add_antithesis(anti));
+    assert!(cycle.synthesize("A and not A".to_string(), 0.8));
+    assert!(cycle.is_complete());
+}
+
+#[test]
+fn synthesize_without_antithesis() {
+    let thesis = Thesis::new("A".to_string(), 0.5);
+    let mut cycle = DialecticalCycle::new(thesis);
+    assert!(!cycle.synthesize("something".to_string(), 0.8));
+    assert!(cycle.synthesis.is_none());
+}

--- a/proto-wuxing/tests/element_compatibility.rs
+++ b/proto-wuxing/tests/element_compatibility.rs
@@ -1,0 +1,45 @@
+use proto_wuxing::{Element, HeavenlyStem, WuxingElement, YinYang, Zodiac};
+
+#[test]
+fn branch_compatibility_matches_element() {
+    let elem = WuxingElement::with_branches(
+        Element::Wood,
+        YinYang::Yang,
+        Zodiac::Tiger,
+        HeavenlyStem::Jia,
+    );
+    assert!(elem.is_branch_compatible());
+}
+
+#[test]
+fn branch_compatibility_mismatch_element() {
+    let elem = WuxingElement::with_branches(
+        Element::Wood,
+        YinYang::Yang,
+        Zodiac::Dragon,
+        HeavenlyStem::Jia,
+    );
+    assert!(!elem.is_branch_compatible());
+}
+
+#[test]
+fn stem_compatibility_matches_element() {
+    let elem = WuxingElement::with_branches(
+        Element::Metal,
+        YinYang::Yin,
+        Zodiac::Monkey,
+        HeavenlyStem::Geng,
+    );
+    assert!(elem.is_stem_compatible());
+}
+
+#[test]
+fn stem_compatibility_mismatch_element() {
+    let elem = WuxingElement::with_branches(
+        Element::Metal,
+        YinYang::Yin,
+        Zodiac::Monkey,
+        HeavenlyStem::Jia,
+    );
+    assert!(!elem.is_stem_compatible());
+}


### PR DESCRIPTION
## Summary
- create `tests` dirs for `proto-wuxing` and `proto-dialectics`
- test `WuxingElement` compatibility helpers
- test `DialecticalCycle` antithesis and synthesis logic

## Testing
- `cargo test`
